### PR TITLE
Do not cache default values across subsequent invocations

### DIFF
--- a/mimer-config/src/test/java/com/avanza/astrix/config/MapConfigSourceTest.java
+++ b/mimer-config/src/test/java/com/avanza/astrix/config/MapConfigSourceTest.java
@@ -15,14 +15,18 @@
  */
 package com.avanza.astrix.config;
 
-
-import org.junit.jupiter.api.Test;
-
-import java.util.HashMap;
-
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
 
 class MapConfigSourceTest {
 
@@ -65,4 +69,33 @@ class MapConfigSourceTest {
 		assertThat(source.get("property3"), equalTo("value3"));
 	}
 
+	@Test
+	void shouldGetNewDefaultValuesEachTime() {
+		// Arrange
+		final DynamicConfig dynamicConfig = DynamicConfig.create(new MapConfigSource());
+
+		// Act
+		final String v1 = dynamicConfig.getStringProperty("key", "first-default").get();
+		final String v2 = dynamicConfig.getStringProperty("key", "second-default").get();
+
+		// Assert
+		assertThat(v1, equalTo("first-default"));
+		assertThat(v2, equalTo("second-default"));
+	}
+
+	@Test
+	void shouldGetNewDefaultValuesEachTimeForIntListProperties() {
+		// Arrange
+		final DynamicConfig dynamicConfig = DynamicConfig.create(new MapConfigSource());
+
+		// Act
+		final DynamicListProperty<Integer> emptyList1 = dynamicConfig.getIntListProperty("key", Collections.emptyList());
+		final DynamicListProperty<Integer> emptyList2 = dynamicConfig.getIntListProperty("key", new ArrayList<>());
+		final DynamicListProperty<Integer> list = dynamicConfig.getIntListProperty("key", Arrays.asList(1, 2));
+
+		// Assert
+		assertThat(emptyList1, sameInstance(emptyList2));
+		assertThat(emptyList1.get(), equalTo(Collections.emptyList()));
+		assertThat(list.get(), containsInAnyOrder(1, 2));
+	}
 }


### PR DESCRIPTION
* Separate cached `DynamicProperty` instances not only by their type and property name, but also by which default value the applicaiton requests.
* Reason for separating is to make different invocations to, for example, `getStringProperty(key, default)` not always return the default value from the first invocation for subsequent invocations to the property value, if the value is missing from the config source.
* Previously, code like the following for an empty config source:
```
String v1 = dynamicConfig.getStringProperty("key", "first").get();
String v2 = dynamicConfig.getStringProperty("key", "second").get();
```
.. would yield the value `"first"` for `v2`. With this commit, `v2` will instead get the value `"second"`.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
